### PR TITLE
fix: inherit color on some elements

### DIFF
--- a/wipe.css
+++ b/wipe.css
@@ -89,6 +89,7 @@ textarea {
   font: inherit;
   -webkit-font-smoothing: inherit;
   letter-spacing: inherit;
+  color: inherit;
   background: none;
   vertical-align: top;
 }


### PR DESCRIPTION
some elements colors weren’t been `wipe`d, and they remained with browser standards (at least on chrome)

i’ve did a little [codepen proof](https://codepen.io/vitordino/pen/yLLLBrR) to help guide us fixing it :tada: