### PR TITLE
fix(html): remove smooth scroll

### DIFF
--- a/wipe.css
+++ b/wipe.css
@@ -14,14 +14,14 @@
 /**
  * 1. Prevent certain mobile browsers from automatically zooming fonts.
  * 2. Border box sizing 
- * 3. Smooth scroll  
+ * 3. Default scroll behavior (not smooth)
  */
 
 html {
   -ms-text-size-adjust: 100%; /* 1 */
   -webkit-text-size-adjust: 100%; /* 1 */
   box-sizing: border-box; /* 2 */
-  scroll-behavior: smooth; /* 3 */
+  scroll-behavior: auto; /* 3 */
 }
 
 /**


### PR DESCRIPTION
i think as smooth scroll isn’t default on any browser — and our idea is to get rid of anything on the way — the default `scroll-behavior` should be set to `auto` (and immediately jump to the point)